### PR TITLE
[comparator] $nin(String, [RegExp()]) ?

### DIFF
--- a/lib/filtr.js
+++ b/lib/filtr.js
@@ -87,7 +87,7 @@ _in = function (a, b) {
   if (b.length == 0)
     return true
   return b.some(function(v){
-    return _eq(a, v);
+    return _eq(v, a);
   })
 }
 

--- a/test/comparators.js
+++ b/test/comparators.js
@@ -71,11 +71,15 @@ describe('comparator', function () {
   it('$in should work', function () {
     comparator.$in(1,[0,1,2]).should.be.true;
     comparator.$in(4,[0,1,2]).should.be.false;
+    comparator.$in('test',['test1', 'test2', 'test3']).should.be.false;
+    comparator.$in('test1',['test1', 'test2', 'test3']).should.be.true;
   });
 
   it('$nin should work', function () {
     comparator.$nin(1,[0,1,2]).should.be.false;
     comparator.$nin(4,[0,1,2]).should.be.true;
+    comparator.$nin('test',['test1', 'test2', 'test3']).should.be.true;
+    comparator.$nin('test1',['test1', 'test2', 'test3']).should.be.false;
   });
 
   it('$size should work', function () {
@@ -89,8 +93,10 @@ describe('comparator', function () {
     comparator.$eq("test", /t..t/im).should.be.true;
     comparator.$eq("test", /test./im).should.be.false;
     comparator.$not("test", /t..t/im).should.be.false;
-    comparator.$in("test", [/t..t/im]).should.be.true;
-    comparator.$nin("test", [/t..t/im]).should.be.false;
+    comparator.$in(/t..t/im, ['abc']).should.be.false;
+    comparator.$in(/t..t/im, ['test', 'abc']).should.be.true;
+    comparator.$nin(/t..t/im, ['abc']).should.be.true;
+    comparator.$nin(/t..t/im, ['test', 'abc']).should.be.false;
   });
 
   it('$or should work', function () {


### PR DESCRIPTION
@nashibao 

```
comparator.$nin('test',['test1', 'test2', 'test3']).should.be.true;
```

（探す文字列、探される文字列の配列）なのに、

```
comparator.$nin("test", [/t..t/im]).should.be.false;
```

（探す文字列、探される正規表現の配列）になっています。

```
comparator.$nin(/t..t/im, ['test', 'abc']).should.be.false;
```

（探す正規表現、探される文字列の配列）ではないかなと。。。
