### PR TITLE
mongoのクエリと結果が一致しないケースの修正

### DIFF
--- a/lib/filtr.js
+++ b/lib/filtr.js
@@ -76,6 +76,12 @@ Filtr.version = '0.3.0';
  */
 
 _eq = function (a, b) {
+  if (a instanceof Array && b instanceof Array) {
+    if (a.length != b.length) return false;
+    for (var i=0; i<a.length; i++)
+      if (a[i] != b[i]) return false;
+    return true;
+  }
   if (!(b instanceof RegExp))
     return a == b;
   if (a == null)

--- a/lib/filtr.js
+++ b/lib/filtr.js
@@ -82,6 +82,9 @@ _eq = function (a, b) {
       if (a[i] != b[i]) return false;
     return true;
   }
+  if (a instanceof Array) {
+    return a.some(function(v) {return _eq(v, b)})
+  }
   if (!(b instanceof RegExp))
     return a == b;
   if (a == null)

--- a/lib/filtr.js
+++ b/lib/filtr.js
@@ -491,6 +491,7 @@ function parseQuery (query) {
       if ('string' == typeof params
       || 'number' == typeof params
       || 'boolean' == typeof params
+      || Array.isArray(params)
       || params instanceof RegExp) {
         qry.test = parseFilter({ $eq: params });
         qry.path = parsePath(cmd);

--- a/lib/filtr.js
+++ b/lib/filtr.js
@@ -604,7 +604,7 @@ function _testFilter (els, stack) {
           return false;
         }
       } else {
-        if (arrayOperators[test.test]){
+        if (arrayOperators[test.test] || Array.isArray(params)){
           if (!test.fn(els, params))
             return false;
         } else {

--- a/test/comparators.js
+++ b/test/comparators.js
@@ -46,6 +46,13 @@ describe('comparator', function () {
     comparator.$all(["t1","t2","t3"],[/t4/im]).should.be.false;
   });
 
+  it('"array to array" $eq should work', function () {
+    comparator.$eq([1, 2], [1, 2]).should.be.true;
+    comparator.$eq([1, 2], [2, 1]).should.be.false;
+    comparator.$eq([1, 2], [1]).should.be.false;
+    comparator.$eq([1, 2], [1, 2, 3]).should.be.false;
+  });
+
   it('$exists should work', function () {
     var a = undefined
       , b = {c: 'hi'};
@@ -71,11 +78,17 @@ describe('comparator', function () {
   it('$in should work', function () {
     comparator.$in(1,[0,1,2]).should.be.true;
     comparator.$in(4,[0,1,2]).should.be.false;
+    comparator.$in([4],[0,1,2]).should.be.false;
+    comparator.$in([0,1,2],[0,1,2]).should.be.true;
+    comparator.$in([0,4],[0,1,2]).should.be.true;
   });
 
   it('$nin should work', function () {
     comparator.$nin(1,[0,1,2]).should.be.false;
     comparator.$nin(4,[0,1,2]).should.be.true;
+    comparator.$nin([4],[0,1,2]).should.be.true;
+    comparator.$nin([0,1,2],[0,1,2]).should.be.false;
+    comparator.$nin([0,4],[0,1,2]).should.be.false;
   });
 
   it('$size should work', function () {

--- a/test/query.js
+++ b/test/query.js
@@ -197,6 +197,47 @@ describe('Query', function () {
       Q.test({ hello: {universe: [{ parent: 'filtr'}]} }, { type: 'single' }).should.be.false;
     });
 
+    it('should assume if array to array: 配列の検索', function () {
+      var query = { 'arrayField': [ 'abc', 'def', 'ghi'] }
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({ 'arrayField': ['abc', 'def', 'ghi'] }, { type: 'single' }).should.be.true;
+    });
+
+    it('should assume if array to array: 同じ値が重複しているケース', function () {
+      var query = { 'arrayField': [ 'abc', 'def', 'ghi'] }
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({ 'arrayField': ['abc', 'def', 'ghi', 'abc'] }, { type: 'single' }).should.be.false;
+    });
+    it('should assume if array to array: 並び順が違うケース', function () {
+      var query = { 'arrayField': [ 'abc', 'def', 'ghi'] }
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({ 'arrayField': ['abc', 'ghi', 'def'] }, { type: 'single' }).should.be.false;
+    });
+
+    it('should assume $eq if array to array', function () {
+      var query = { 'arrayField': { $eq: [ 'abc', 'def', 'ghi'] } }
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({ 'arrayField': ['abc', 'def', 'ghi'] }, { type: 'single' }).should.be.true;
+    });
+
+    it('should not $eq', function () {
+      var query = { 'arrayField': [ /abc/im ] }
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({ 'arrayField': ['abc', 'def', 'ghi'] }, { type: 'single' }).should.be.false;
+    });
+
+    it('should not $eq', function () {
+      var query = { 'arrayField': [ /abc/im, /def/im, /ghi/im ] }
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({ 'arrayField': ['abc', 'def', 'ghi'] }, { type: 'single' }).should.be.false;
+    });
+
   });
 
   // TODO: All nesting options.


### PR DESCRIPTION
二点修正しています。
- 配列と配列の$eqが完全一致になっていなかった
- 配列に対する$in, $ninが部分一致になっていなかった
