### PR TITLE
配列を検索対象とする$neが正しく動作していなかった問題の修正

### DIFF
--- a/lib/filtr.js
+++ b/lib/filtr.js
@@ -18,6 +18,8 @@ var traversable = {
 var arrayOperators = {
   $all: true,
   $elemMatch: true,
+  $eq: true,
+  $ne: true,
   $size: true
 }
 

--- a/test/comparators.js
+++ b/test/comparators.js
@@ -73,6 +73,18 @@ describe('comparator', function () {
   it('$ne should work', function () {
     comparator.$ne(12,12).should.be.false;
     comparator.$ne(12,11).should.be.true;
+
+    comparator.$ne([12],12).should.be.false;
+    comparator.$ne([12],11).should.be.true;
+
+    comparator.$ne([1, 12],12).should.be.false;
+    comparator.$ne([1, 12],11).should.be.true;
+
+    comparator.$ne(['abc', 'def'],'abc').should.be.false;
+    comparator.$ne(['abc', 'def'],'xxx').should.be.true;
+
+    comparator.$ne([1,2],[1,2]).should.be.false;
+    comparator.$ne([1,2],[2,1]).should.be.true;
   });
 
   it('$in should work', function () {
@@ -103,6 +115,8 @@ describe('comparator', function () {
     comparator.$eq("test", /test./im).should.be.false;
     comparator.$not("test", /t..t/im).should.be.false;
     comparator.$in("test", [/t..t/im]).should.be.true;
+    comparator.$in("abc", [/t..t/im, /ab*c/im]).should.be.true;
+    comparator.$in("false", [/t..t/im, /abc/im]).should.be.false;
     comparator.$nin("test", [/t..t/im]).should.be.false;
   });
 

--- a/test/query.js
+++ b/test/query.js
@@ -252,6 +252,22 @@ describe('Query', function () {
       Q2.test({ 'arrayField': ['def', 'abc', 'ghi'] }, { type: 'single' }).should.be.true;
     });
 
+    it('should $ne work', function () {
+      var query = {'sets': {$ne: 'Chrome'}}
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({sets: ['Chrome', 'abc']}, {type: 'single'}).should.be.false;
+      Q.test({sets: ['Firefox', 'abc']}, {type: 'single'}).should.be.true;
+    });
+
+    it('should $eq work', function () {
+      var query = {'sets': {$eq: 'Chrome'}}
+        , Q = filtr(query);
+      Q.stack.should.have.length(1);
+      Q.test({sets: ['Chrome', 'abc']}, {type: 'single'}).should.be.true;
+      Q.test({sets: ['Firefox', 'abc']}, {type: 'single'}).should.be.false;
+    });
+
   });
 
   // TODO: All nesting options.


### PR DESCRIPTION
https://github.com/plaidev/filtr/blob/0.3.2/lib/filtr.js#L600-L609

この部分でarrayOperatorsでないoperator、かつ、チェック対象が配列であるときに、「どれか一つでもtrueならばtrue」としている処理がありますが、

```
  var query = {'sets': {$eq: 'Chrome'}}
  //<略>
  Q.test({sets: ['Chrome', 'abc']}, {type: 'single'}).should.be.false;
```

この処理を、`"Chrome" != "Chrome"` or `"abc" != "Chrome"`として処理してしまい、正確に$eqの逆になりません。（本来なら`"Chrome" != "Chrome"` **and** `"abc" != "Chrome"`として処理するべき）

arrayOperatorsに$neと$eqを入れ、_eqに配列の場合の処理も任せるように変更します。
